### PR TITLE
basic unix support

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -6,9 +6,41 @@ pub use self::inner::{current_time, file_last_modified, get_cache_dir_for};
 
 #[cfg(unix)]
 mod inner {
+    extern crate time;
+
     use std::path::{Path, PathBuf};
+    use std::{cmp, env, fs};
+    use std::os::unix::fs::MetadataExt;
     use error::{MainError, Blame};
-    use std::env;
+
+    /**
+    Gets the last-modified time of a file, in milliseconds since the UNIX epoch.
+    */
+    pub fn file_last_modified(file: &fs::File) -> u64 {
+        let mtime_s_1970_utc = file.metadata()
+            .map(|md| md.as_raw().mtime())
+            .unwrap_or(0);
+
+        let mtime_s_1970_utc = cmp::max(0, mtime_s_1970_utc);
+        mtime_s_1970_utc as u64 * 1000
+    }
+
+    /**
+    Gets the current system time, in milliseconds since the UNIX epoch.
+    */
+    pub fn current_time() -> u64 {
+        /*
+        This is kinda dicey, since *ideally* both this function and `file_last_modified` would be using the same underlying APIs.  They are not, insofar as I know.
+        */
+        let now_1970_utc = time::now_utc().to_timespec();
+        if now_1970_utc.sec < 0 || now_1970_utc.nsec < 0 {
+            // Fuck it.
+            return 0
+        }
+        let now_ms_1970_utc = (now_1970_utc.sec as u64 * 1000)
+            + (now_1970_utc.nsec as u64 / 1_000_000);
+        now_ms_1970_utc
+    }
 
     pub fn get_cache_dir_for<P>(product: P) -> Result<PathBuf, MainError>
     where P: AsRef<Path> {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -4,6 +4,29 @@ This module is for platform-specific stuff.
 
 pub use self::inner::{current_time, file_last_modified, get_cache_dir_for};
 
+#[cfg(unix)]
+mod inner {
+    use std::path::{Path, PathBuf};
+    use error::{MainError, Blame};
+    use std::env;
+
+    pub fn get_cache_dir_for<P>(product: P) -> Result<PathBuf, MainError>
+    where P: AsRef<Path> {
+        let home = match env::var_os("HOME") {
+            Some(val) => val,
+            None => return Err((Blame::Human, "$HOME is not defined").into())
+        };
+
+        match product.as_ref().to_str() {
+            Some(s) => {
+                let folder = format!(".{}", s.to_lowercase());
+                Ok(Path::new(&home).join(folder))
+            },
+            None => Err("product for `get_cache_dir_for` was not utf8".into())
+        }
+    }
+}
+
 #[cfg(windows)]
 pub mod inner {
     #![allow(non_snake_case)]


### PR DESCRIPTION
`current_time` could actually be cross-platform in this case, but I've left them separate for now.