### PR TITLE
check $CARGO_HOME before $HOME on unix

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -58,9 +58,13 @@ mod inner {
     */
     pub fn get_cache_dir_for<P>(product: P) -> Result<PathBuf, MainError>
     where P: AsRef<Path> {
-        let home = match env::var_os("HOME") {
+        // try $CARGO_HOME then fall back to $HOME
+        let home = match env::var_os("CARGO_HOME") {
             Some(val) => val,
-            None => return Err((Blame::Human, "$HOME is not defined").into())
+            None => match env::var_os("HOME") {
+                Some(val) => val,
+                None => return Err((Blame::Human, "neither $CARGO_HOME nor $HOME is defined").into())
+            }
         };
 
         match product.as_ref().to_str() {


### PR DESCRIPTION
Fixes #9 on Linux (and ~~presumably~~ OSX). Does not attempt to fix on Windows since multirust doesn't work there anyway, plus a comment in the code says listening to Cargo is wrong on Windows.

Also, `Blame::Human` is a great error :)