### PR TITLE
work around Rust bug to allow macros in expr

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -34,9 +34,10 @@ pub const FILE_TEMPLATE: &'static str = r#"%b"#;
 pub const EXPR_TEMPLATE: &'static str = r#"
 %p
 fn main() {
-    println!("{:?}", 
+    let __cargo_script_expr = {
 {%b}
-    );
+    };
+    println!("{:?}",  __cargo_script_expr);
 }
 "#;
 


### PR DESCRIPTION
This is a workaround for a bug in Rust (rust-lang/rust#31946) which causes parsing to fail on macros defined within calls to `println!`.