### PR TITLE
Updates clap to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "cargo-script"
 version = "0.1.5"
 dependencies = [
- "clap 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hoedown 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -37,17 +37,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clap"
-version = "1.4.5"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -91,6 +105,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -231,6 +250,16 @@ dependencies = [
 [[package]]
 name = "unicode-segmentation"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,7 @@ rustc-serialize = "0.3.16"
 shaman = "0.1.0"
 time = "0.1.25"
 toml = "0.1.20"
-
-[dependencies.clap]
-version = "1.4.5"
-
-# Disable the "color" feature because it just outputs garbage on Windows.
-default-features = false
-features = ["suggestions"]
+clap = "2.4.0"
 
 [target.i686-pc-windows-gnu.dependencies]
 ole32-sys = "0.1.0"


### PR DESCRIPTION
This commit updates `clap` to v2.4.0 which contains a bunch of bug fixes
and improvements. This PR also includes building `clap` with all default
features as the old `color` feature is no longer built on Windows
systems and therefore no longer an issue.

Besides the bump in version of `clap`, and associated simple name changes (of
which only 3 affected this crate) such as `add_all`->`args` (etc.), the
`owned_vec_string` function has been changed slightly to reflect `clap`s returning
an `Iterator<Item=&str>` instead of a `Vec<&str>`.

------

I was updating `cargo-extras` and since I'm not sure how to allow different `[bin]` tables to accept different major versions of a particular crate (`clap` in this case), this was one of the subcommands that needed an update to build `cargo-extras`.

The `color` feature shouldn't have a negative affect anymore since there are now `cfg` flags in place to ensure it doesn't do anything in Windows. But you may want to double check this real quick since I'm not typically a windows dev.