### PR TITLE
script -e: Keep temporaries around long enough to print them

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -34,10 +34,9 @@ pub const FILE_TEMPLATE: &'static str = r#"%b"#;
 pub const EXPR_TEMPLATE: &'static str = r#"
 %p
 fn main() {
-    let __cargo_script_expr = {
+    println!("{:?}", {
 {%b}
-    };
-    println!("{:?}",  __cargo_script_expr);
+    });
 }
 "#;
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -34,9 +34,9 @@ pub const FILE_TEMPLATE: &'static str = r#"%b"#;
 pub const EXPR_TEMPLATE: &'static str = r#"
 %p
 fn main() {
-    println!("{:?}", {
-{%b}
-    });
+    match ({%b}) {
+        __cargo_script_expr => println!("{:?}", __cargo_script_expr)
+    }
 }
 "#;
 

--- a/tests/tests/expr.rs
+++ b/tests/tests/expr.rs
@@ -13,6 +13,12 @@ fn test_expr_dnc() {
 }
 
 #[test]
+fn test_expr_temporary() {
+    let out = cargo_script!("-e", "[1].iter().max()").unwrap();
+    assert!(out.success());
+}
+
+#[test]
 fn test_expr_dep() {
     let out = cargo_script!("-D", "boolinator=0.1.0",
         "-e", with_output_marker!(


### PR DESCRIPTION
For cargo script -e, simply pass the block to println. This allows
printing more expressions (those that borrow from temporaries that go
out of scope at the end of the statement).

For example, this makes cargo script -e '[1, 2, 3].iter().max()' compile.