### PR TITLE
Be forward compatible with rust-lang/rust#59928

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -132,7 +132,7 @@ pub trait ResultExt {
 impl<T> ResultExt for Result<T> {
     type Ok = T;
 
-    fn err_tag<S>(self, msg: S) -> Result<Self::Ok>
+    fn err_tag<S>(self, msg: S) -> Result<T>
     where S: Into<Cow<'static, str>> {
         match self {
             Ok(v) => Ok(v),


### PR DESCRIPTION
Hello! In https://github.com/rust-lang/rust/pull/59928 we are making https://github.com/rust-lang/rust/issues/57644 a deny-by-default lint. To be forward compatible with that, here's a simple fix.